### PR TITLE
Fix derp, now allows any prefix before url

### DIFF
--- a/src/main/java/pcl/lc/irc/hooks/xkcd.java
+++ b/src/main/java/pcl/lc/irc/hooks/xkcd.java
@@ -93,7 +93,7 @@ public class xkcd extends AbstractListener {
 		chan = event.getChannel().getName();
 		if (event.getMessage().contains("xkcd.com") && enabledChannels.contains(event.getChannel().getName())) {
 			Pattern pattern = Pattern.compile(
-					"^(?:https?:\\/\\/)?(?:www\\.)?xkcd\\.com\\/([0-9]+)", 
+					"(?:https?:\\/\\/)?(?:www\\.)?(?<!what-if\\.)xkcd\\.com\\/([0-9]+)", 
 					Pattern.CASE_INSENSITIVE);
 			Matcher matcher = pattern.matcher(event.getMessage());
 			if (matcher.find()){


### PR DESCRIPTION
Now explicitly excludes urls containing "what-if."