### PR TITLE
Make 8ball accept just ^ as a valid question

### DIFF
--- a/src/main/java/pcl/lc/irc/hooks/EightBall.java
+++ b/src/main/java/pcl/lc/irc/hooks/EightBall.java
@@ -23,19 +23,17 @@ public class EightBall extends AbstractListener {
 		local_command = new Command("eightball", 0) {
 			@Override
 			public void onExecuteSuccess(Command command, String nick, String target, GenericMessageEvent event, String params) {
-				if (params.length() > 6) {
-					if (params.matches(".*\\?$")) {
-						ArrayList<String> messages = new ArrayList<>();
-						messages.add("Signs point to yes");
-						messages.add("Without a doubt");
-						messages.add("Reply hazy, try again");
-						messages.add("Ask again later");
-						messages.add("My reply is no");
-						messages.add("Outlook not so good");
-						messages.add("[ The Bowling ball doesn't answer ]");
-						Helper.sendMessage(target, messages.get(Helper.getRandomInt(0, messages.size() - 1)), nick);
-						return;
-					}
+				if ((params.length() > 6 && params.matches(".*\\?$")) || params.equals("^")) {
+					ArrayList<String> messages = new ArrayList<>();
+					messages.add("Signs point to yes");
+					messages.add("Without a doubt");
+					messages.add("Reply hazy, try again");
+					messages.add("Ask again later");
+					messages.add("My reply is no");
+					messages.add("Outlook not so good");
+					messages.add("[ The Bowling ball doesn't answer ]");
+					Helper.sendMessage(target, messages.get(Helper.getRandomInt(0, messages.size() - 1)), nick);
+					return;
 				}
 				Helper.sendMessage(target, "I don't think that's a question...", nick);
 			}


### PR DESCRIPTION
This makes the command slightly easier on mobile-client users who don't have access to the up-arrow function most clients have, when given an "Ask again later"