### PR TITLE
Check for Integer class in DatabaseEntry.GetByField

### DIFF
--- a/src/main/java/pcl/lc/utils/DatabaseEntry.java
+++ b/src/main/java/pcl/lc/utils/DatabaseEntry.java
@@ -124,7 +124,7 @@ public class DatabaseEntry {
 
 		if (value == null)
 			str_value = "null";
-		else if (value.getClass() == int.class)
+		else if (value.getClass() == int.class || value instanceof Integer)
 			str_value = String.valueOf(value);
 		else if (value.getClass() == double.class)
 			str_value = String.valueOf(value);


### PR DESCRIPTION
Since apparenlty getClass() == int.class doesn't cover lang.Integer objects.